### PR TITLE
Set a default secret key in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     environment:
       DJANGO_ALLOWED_HOSTS:
       DJANGO_DATABASE_URL: 'postgres://postgres@db/postgres'
-      DJANGO_DEBUG:
+      DJANGO_DEBUG: 'True'
       DJANGO_SECRET_KEY: 'dev'  # XXX: *Only* for development.
       GOOGLE_MAPS_API_KEY:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+# docker-compose file for local development.
 version: '3'
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       DJANGO_ALLOWED_HOSTS:
       DJANGO_DATABASE_URL: 'postgres://postgres@db/postgres'
       DJANGO_DEBUG:
-      DJANGO_SECRET_KEY:
+      DJANGO_SECRET_KEY: 'dev'  # XXX: *Only* for development.
       GOOGLE_MAPS_API_KEY:
     build:
       context: .


### PR DESCRIPTION
This lets docker-compose work without depending on the default `.env` file, or manually setting the secret key.